### PR TITLE
Added fix for mutliple server regression

### DIFF
--- a/lib/fixed-server.js
+++ b/lib/fixed-server.js
@@ -89,13 +89,12 @@ FixedServerFactory.prototype = {
     var server = this.createServer(fixtureNames);
     var that = this;
     before(function () {
-      // Create local fake server
       server.listen(that.options.port);
-      this.server = server;
     });
     after(function (done) {
-      this.server.destroy(done);
+      server.destroy(done);
     });
+    return server;
   }
 };
 

--- a/test/fixed-server_test.js
+++ b/test/fixed-server_test.js
@@ -101,3 +101,13 @@ describe('A FixedServer loaded from a file', function () {
     expect(JSON.parse(this.body)).to.deep.equal([{data:true}]);
   });
 });
+
+// DEV: Regression test for https://github.com/uber/fixed-server/issues/2
+describe('Multiple FixedServers run in the same test', function () {
+  (new FixedServer(serverOptions)).run();
+  (new FixedServer(extend({}, serverOptions, {port: 1338}))).run();
+
+  it('do not conflict while shutting down', function () {
+    // DEV: This is automatic since the regression was in the mocha helpers
+  });
+});


### PR DESCRIPTION
As noted in #2, we have a regression when multiple `fixed-servers` are run in the same test. This PR fixes that issue.

In this PR:
- Remove writing to `this` during mocha tests
- Add regression test against issue to prevent future occurrences

/cc @mlmorg 
