### PR TITLE
Move run method to server prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ express().get('/hello', function (req, res) {
 });
 ```
 
+#### `server.run()`
+Helper method for running the server inside of `mocha` tests
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint via [grunt](https://github.com/gruntjs/grunt) and test via `npm test`.
 

--- a/lib/fixed-server.js
+++ b/lib/fixed-server.js
@@ -23,6 +23,18 @@ FixedServer.prototype = {
   installFixture: function (fixture) {
     // Add the route to the
     this.app[fixture.method](fixture.route, fixture.response);
+  },
+
+  // Helper for mocha tests
+  run: function () {
+    var that = this;
+    before(function () {
+      that.listen();
+    });
+    after(function (done) {
+      that.destroy(done);
+    });
+    return this;
   }
 };
 
@@ -87,15 +99,7 @@ FixedServerFactory.prototype = {
 
   // Create helper for mocha tests
   run: function (fixtureNames) {
-    var server = this.createServer(fixtureNames);
-    var that = this;
-    before(function () {
-      server.listen();
-    });
-    after(function (done) {
-      server.destroy(done);
-    });
-    return server;
+    return this.createServer(fixtureNames).run();
   }
 };
 


### PR DESCRIPTION
It might be useful for people to be able to use the mocha helper from the server itself, after using `fixedServer.createServer()`. This gives them the ability to do that.
