### PR TITLE
Add initialize function for server setup

### DIFF
--- a/lib/fixed-server.js
+++ b/lib/fixed-server.js
@@ -8,9 +8,17 @@ function noop() {}
 function FixedServer(options) {
   this.app = express();
   this.options = options || {};
+
+  if (this.options.initialize) {
+    this.initialize(this.options.initialize);
+  }
 }
 FixedServer.prototype = {
   // Setup/teardown methods
+  initialize: function (initFunc) {
+    initFunc(this.app);
+    return this;
+  },
   listen: function (port) {
     this._app = this.app.listen(port || this.options.port);
   },

--- a/test/fixed-server_test.js
+++ b/test/fixed-server_test.js
@@ -111,3 +111,26 @@ describe('Multiple FixedServers run in the same test', function () {
     // DEV: This is automatic since the regression was in the mocha helpers
   });
 });
+
+describe('A FixedServer with an initialize function', function () {
+  var fixedServer = new FixedServer(extend({}, serverOptions, {
+    initialize: function (app) {
+      app.locals.message = 'initialized';
+    }
+  }));
+  fixedServer.addFixture('GET 200 /hello', {
+    method: 'get',
+    route: '/hello',
+    response: function (req, res) {
+      res.send(req.app.locals.message);
+    }
+  });
+  fixedServer.run('GET 200 /hello');
+  saveRequest(getUrl('/hello'));
+
+  it('runs the initialize function on server create', function () {
+    expect(this.err).to.equal(null);
+    expect(this.res.statusCode).to.equal(200);
+    expect(this.body).to.equal('initialized');
+  });
+});


### PR DESCRIPTION
I often find myself wanting to interact with the express server and set it up a certain way before making requests to it. For example, if you're testing a global middleware and want to use some jade templating:

``` js
var fixedServer = FixedServer.fromFile('./fixtures/fixed-server', {
  port: 1337,
  initialize: function (app) {
    app.engine('jade', jade.__express);
    app.set('view engine', 'jade');
    app.use(myGlobalMiddleware());
  }
});
```

And if you'd like to set your server up on a per-test basis, you could do something like (with the addition of #5):

``` js
fixedServer.createServer(['GET 200 /']).setup(mySetupFunc).run();
```

This might not be the best approach, but something along these lines would be very useful!
